### PR TITLE
✨ Fix #16: Adds command line argument `-p` to print the local emoji cache path.

### DIFF
--- a/src/emojis.rs
+++ b/src/emojis.rs
@@ -30,7 +30,7 @@ pub fn update_cache() -> Result<String, Box<dyn Error>> {
     Ok(emojis_json)
 }
 
-fn cache_dir() -> Result<PathBuf, Box<dyn Error>> {
+pub fn cache_dir() -> Result<PathBuf, Box<dyn Error>> {
     let path = dirs::cache_dir().unwrap().join(CACHE_DIR);
     std::fs::create_dir_all(&path)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,10 @@ struct Args {
     /// Run as git commit hook.
     #[arg(long, value_delimiter = ' ', num_args = 1..3)]
     hook: Vec<String>,
+
+    /// Prints the local emoji cache path.
+    #[arg(short, long, default_value_t = false)]
+    print_emoji_cache_path: bool,
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -40,8 +44,14 @@ fn main() -> Result<(), Box<dyn Error>> {
         install_hook()?;
 
         return Ok(());
-    } else if args.update_cache {
+    }
+    else if args.update_cache {
         emojis::update_cache()?;
+
+        return Ok(());
+    }
+    else if args.print_emoji_cache_path {
+        println!("{}", emojis::cache_dir()?.display());
 
         return Ok(());
     }


### PR DESCRIPTION
Fixes #16