### PR TITLE
🔥 Remove exec line from git hook

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -140,6 +140,5 @@ const HOOK_PATH: &str = ".git/hooks/prepare-commit-msg";
 const HOOK_CONTENT: &str = r#"
 #!/usr/bin/env bash
 # gimoji as a commit hook
-exec < /dev/tty
 gimoji --hook $1 $2
 "#;


### PR DESCRIPTION
I copied over that line from the git hook gitmoji-cli installs and still not sure what it does. I had assumed it's needed but it seems it isn't.

Also while I don't know if the git hook works on Windows at all, this line will very likely fail there.