### PR TITLE
📝 Drop `Core` from Fedora's name

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ is based on) [gitmoji-cli] but written in Rust.
 
 ## Installation
 
-### Fedora Core (>= 38)
+### Fedora (>= 38)
 
 ```bash
 sudo dnf install gimoji

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ is based on) [gitmoji-cli] but written in Rust.
 
 ## Installation
 
-### Fedora (>= 38)
+### Fedora (>= 37)
 
 ```bash
 sudo dnf install gimoji


### PR DESCRIPTION
Thanks to Fabio Valentini for pointing this out:

> "Fedora Core" isn't a thing any more - Fedora 7 dropped the "Core" from the name in, uhm ... 2007: https://fedoraproject.org/wiki/Releases/7

---

Zeeshan Ali Khan on behalf of MBition GmbH.

[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md#mbition-gmbh).
