### PR TITLE
✨ Quit on Ctrl+C

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod terminal;
 
 use arboard::Clipboard;
 use clap::{command, Parser};
-use crossterm::event::{read, Event, KeyCode};
+use crossterm::event::{read, Event, KeyCode, KeyModifiers};
 use ratatui::layout::{Constraint, Layout};
 use selection_view::SelectionView;
 use std::{error::Error, fs::File, io::Write};
@@ -119,7 +119,13 @@ fn select_emoji() -> Result<Option<String>, Box<dyn Error>> {
                 }
                 KeyCode::Down => filtered_view.move_down(),
                 KeyCode::Up => filtered_view.move_up(),
-                KeyCode::Char(c) => search_entry.append(c),
+                KeyCode::Char(c) => {
+                    if c == 'c' && event.modifiers.contains(KeyModifiers::CONTROL) {
+                        break None;
+                    } else {
+                        search_entry.append(c)
+                    }
+                }
                 KeyCode::Backspace => {
                     search_entry.delete_last();
                 }


### PR DESCRIPTION
For a terminal-based app, some users expect Ctrl+C to work as universal "quit this". Let's implement this. Note that we only check for Control to be *in* the modifier set (but not exclusively so), so Alt+Control+C or similar would also quit. That can be fixed separately if there's ever a need for that.

Fixes #39