### PR TITLE
✨ Add support for light terminal backgrounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "coolor"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad6ac2088e244fd157068daf566f17f7b46d5c543273582bc8b2875233bdfb86"
+
+[[package]]
+name = "crossterm"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2102ea4f781910f8a5b98dd061f4c2023f479ce7bb1236330099ceb5a93cf17"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,13 +353,14 @@ version = "0.5.1"
 dependencies = [
  "arboard",
  "clap",
- "crossterm",
+ "crossterm 0.26.1",
  "databake",
  "nix 0.26.2",
  "ratatui",
  "regex",
  "serde",
  "serde_json",
+ "terminal-light",
 ]
 
 [[package]]
@@ -489,6 +512,19 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
+dependencies = [
+ "bitflags 1.3.2",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nix"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
@@ -631,7 +667,7 @@ checksum = "ce841e0486e7c2412c3740168ede33adeba8e154a15107b879d8162d77c7174e"
 dependencies = [
  "bitflags 1.3.2",
  "cassowary",
- "crossterm",
+ "crossterm 0.26.1",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -832,6 +868,18 @@ dependencies = [
  "redox_syscall",
  "rustix 0.37.21",
  "windows-sys",
+]
+
+[[package]]
+name = "terminal-light"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9077b39afb70f12391e4c1fcf46319999cfc32b45d605a668052bc4d1b4511af"
+dependencies = [
+ "coolor",
+ "crossterm 0.23.2",
+ "thiserror",
+ "xterm-query",
 ]
 
 [[package]]
@@ -1105,3 +1153,14 @@ name = "xml-rs"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52839dc911083a8ef63efa4d039d1f58b5e409f923e44c80828f206f66e5541c"
+
+[[package]]
+name = "xterm-query"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec02abe9c7efbcb010adc0d90bc4a054653477cd4a3eb8eef5a689799c146a13"
+dependencies = [
+ "mio",
+ "nix 0.22.3",
+ "thiserror",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ crossterm = { version = "0.26.1", features = ["use-dev-tty"] }
 ratatui = "0.21.0"
 regex = { version = "1.8.2", default-features = false, features = ["std", "perf", "unicode-case" ] }
 arboard = { version = "3.2.0", default-features = false, features = ["wayland-data-control"] }
+terminal-light = "1.1.1"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.26", default-features = false, features = ["process"] }

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -1,0 +1,25 @@
+use ratatui::style::Color;
+
+pub struct Colors {
+    pub selected: Color,
+    pub unselected: Color,
+    pub border: Color,
+}
+
+impl Colors {
+    pub fn light() -> Self {
+        Self {
+            selected: Color::Green,
+            unselected: Color::DarkGray,
+            border: Color::DarkGray,
+        }
+    }
+
+    pub fn dark() -> Self {
+        Self {
+            selected: Color::Green,
+            unselected: Color::White,
+            border: Color::White,
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 extern crate self as gimoji;
 
+mod colors;
 mod emoji;
 mod search_entry;
 mod selection_view;
@@ -7,6 +8,7 @@ mod terminal;
 
 use arboard::Clipboard;
 use clap::{command, Parser};
+use colors::Colors;
 use crossterm::event::{read, Event, KeyCode, KeyModifiers};
 use ratatui::layout::{Constraint, Layout};
 use selection_view::SelectionView;
@@ -82,9 +84,14 @@ fn main() -> Result<(), Box<dyn Error>> {
 fn select_emoji() -> Result<Option<String>, Box<dyn Error>> {
     let emojis = &emoji::EMOJIS;
 
+    let colors = match terminal_light::luma() {
+        Ok(luma) if luma > 0.6 => Colors::light(),
+        _ => Colors::dark(),
+    };
+
     let mut terminal = Terminal::setup()?;
-    let mut search_entry = SearchEntry::default();
-    let mut selection_view = SelectionView::new(emojis);
+    let mut search_entry = SearchEntry::new(&colors);
+    let mut selection_view = SelectionView::new(emojis, &colors);
 
     let selected = loop {
         let search_text = search_entry.text();

--- a/src/search_entry.rs
+++ b/src/search_entry.rs
@@ -1,15 +1,23 @@
+use crate::colors::Colors;
 use ratatui::{
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::Span,
     widgets::{Block, Borders, Padding, Paragraph, Widget},
 };
 
-#[derive(Default)]
-pub struct SearchEntry {
+pub struct SearchEntry<'c> {
     text: String,
+    colors: &'c Colors,
 }
 
-impl SearchEntry {
+impl<'c> SearchEntry<'c> {
+    pub fn new(colors: &'c Colors) -> Self {
+        Self {
+            text: String::from(""),
+            colors,
+        }
+    }
+
     pub fn text(&self) -> &str {
         self.text.as_ref()
     }
@@ -27,7 +35,7 @@ impl SearchEntry {
     }
 }
 
-impl Widget for &SearchEntry {
+impl Widget for &SearchEntry<'_> {
     fn render(self, area: ratatui::layout::Rect, buf: &mut ratatui::buffer::Buffer) {
         let (text, style) = if self.text.is_empty() {
             (DEFAULT_TEXT, Style::default().add_modifier(Modifier::DIM))
@@ -38,7 +46,7 @@ impl Widget for &SearchEntry {
             Block::default()
                 .title(TITLE)
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(Color::White))
+                .border_style(Style::default().fg(self.colors.border))
                 .padding(Padding {
                     left: 1,
                     right: 1,


### PR DESCRIPTION
Use termbg to detect a light vs dark terminal background and adjust the colors accordingly. This is merely the minimal implementation to make gimoji render nicely on white backgrounds but the infrastructure is mostly there for more complex styling.

Fixes #40 

Obligatory 4k-quality screenshot of my design skills:
![Screenshot from 2023-08-11 12-09-24](https://github.com/zeenix/gimoji/assets/1487352/1d342051-88bd-4e8c-a86e-26ec6f7c7406)
