### PR TITLE
⏪️ Revert "🔥 Remove exec line from git hook"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -217,5 +217,6 @@ const HOOK_PATH: &str = ".git/hooks/prepare-commit-msg";
 const HOOK_CONTENT: &str = r#"
 #!/usr/bin/env bash
 # gimoji as a commit hook
+exec < /dev/tty
 gimoji --hook $1 $2
 "#;


### PR DESCRIPTION
This reverts commit d13b964272910afca55d817c80e3a5dd34203aed.

Turns out this line was needed after all. Without it, you end up with some garbage in the search bar of the CLI when using `git commit -a`.