### PR TITLE
✨ exit process when selected is None

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use std::{
     error::Error,
     fs::File,
     io::{BufRead, BufReader, Write},
+    process,
 };
 #[cfg(unix)]
 use std::{fs::Permissions, os::unix::prelude::PermissionsExt};
@@ -83,7 +84,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let selected = match select_emoji()? {
         Some(s) => s,
-        None => return Ok(()),
+        None => process::exit(130),
     };
 
     if let Some(path) = commit_file_path {


### PR DESCRIPTION
This addresses https://github.com/zeenix/gimoji/issues/86 

I'm not 100% certain that this exit code will work for all OSes (namely windows), but hopefully the checks will determine this.

Fixes #86.
