### PR TITLE
✨ Exit process on Ctrl+C only

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use std::{
     error::Error,
     fs::File,
     io::{BufRead, BufReader, Write},
+    process,
 };
 #[cfg(unix)]
 use std::{fs::Permissions, os::unix::prelude::PermissionsExt};
@@ -149,7 +150,8 @@ fn select_emoji() -> Result<Option<String>, Box<dyn Error>> {
                 KeyCode::Up => filtered_view.move_up(),
                 KeyCode::Char(c) => {
                     if c == 'c' && event.modifiers.contains(KeyModifiers::CONTROL) {
-                        break None;
+                        let _ = terminal.cleanup();
+                        process::exit(130);
                     } else {
                         search_entry.append(c)
                     }


### PR DESCRIPTION
Fixes https://github.com/zeenix/gimoji/issues/86

See https://github.com/zeenix/gimoji/issues/86#issuecomment-1949616189 for context

`cleanup` is called because without it, the shell prompt seems to get stuck at the end of line when quitting early at this stage:
<img width="892" alt="Screenshot 2024-02-17 at 11 21 57" src="https://github.com/zeenix/gimoji/assets/20417521/0abd32ea-ce45-4e0d-9500-b534dbc92ab0">

Please advise if there's a better way to fix this
