### PR TITLE
🔥 Drop workaround for color scheme detection issues from git hook

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,8 @@ struct Args {
     hook: Vec<String>,
 
     /// The color scheme to use (`GIMOJI_COLOR_SCHEME` environment variable takes precedence).
+    ///
+    /// If not specified, the color scheme is autodetected.
     #[arg(short, long)]
     color_scheme: Option<ColorScheme>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -248,9 +248,20 @@ fn get_color_scheme(args: &Args) -> ColorScheme {
             _ => None,
         })
         .or(args.color_scheme)
-        .unwrap_or_else(|| match terminal_light::luma() {
-            Ok(luma) if luma > 0.6 => ColorScheme::Light,
-            _ => ColorScheme::Dark,
+        .unwrap_or_else(|| {
+            terminal_light::luma()
+                .map(|l| {
+                    if l > 0.6 {
+                        ColorScheme::Light
+                    } else {
+                        ColorScheme::Dark
+                    }
+                })
+                .unwrap_or_else(|e| {
+                    eprintln!("WARNING: Failed to detect terminal luma: {e}. Assuming dark.");
+
+                    ColorScheme::Dark
+                })
         })
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use std::{
     error::Error,
     fs::{File, OpenOptions},
     io::{BufRead, BufReader, Read, Write},
-    process::{self, exit},
+    process::exit,
 };
 #[cfg(unix)]
 use std::{fs::Permissions, os::unix::prelude::PermissionsExt};
@@ -157,7 +157,7 @@ fn select_emoji(colors: Colors) -> Result<Option<String>, Box<dyn Error>> {
                 KeyCode::Char(c) => {
                     if c == 'c' && event.modifiers.contains(KeyModifiers::CONTROL) {
                         let _ = terminal.cleanup();
-                        process::exit(130);
+                        exit(130);
                     } else {
                         search_entry.append(c)
                     }
@@ -235,7 +235,7 @@ fn copy_to_clipboard(s: String) -> Result<(), Box<dyn Error>> {
         Clipboard::new()?.set().text(s)?;
     }
 
-    std::process::exit(0)
+    exit(0)
 }
 
 // Color scheme selection. Precedence: env, arg, detection, default.

--- a/src/main.rs
+++ b/src/main.rs
@@ -253,23 +253,12 @@ fn get_color_scheme(args: &Args) -> ColorScheme {
             _ => None,
         })
         .or(args.color_scheme)
-        .unwrap_or_else(|| {
-            if args.hook.is_empty() {
-                match terminal_light::luma() {
-                    Ok(luma) if luma > 0.6 => ColorScheme::Light,
-                    _ => ColorScheme::Dark,
-                }
-            } else {
-                eprintln!("{}", NO_SCHEME_IN_HOOK_ERROR);
-
-                exit(-1);
-            }
+        .unwrap_or_else(|| match terminal_light::luma() {
+            Ok(luma) if luma > 0.6 => ColorScheme::Light,
+            _ => ColorScheme::Dark,
         })
 }
 
 const HOOK_PATH: &str = ".git/hooks/prepare-commit-msg";
 const HOOK_HEADER: &str = "#!/usr/bin/env bash\n# gimoji as a commit hook\n";
 const HOOK_CMD_TEMPL: &str = "gimoji {color_scheme_arg} --hook \"$1\" \"$2\"";
-
-const NO_SCHEME_IN_HOOK_ERROR: &str =
-    r#"No color scheme specified in the git hook. Please re-install it using `gimoji -i`."#;


### PR DESCRIPTION
With terminal-light 1.3.0 and 1.4.0 (which we already bumped to), we don't need any workarounds.