### PR TITLE
⚡️ Slower compile-time for smaller binary size, for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,4 @@ databake = { version = "0.2.0", features = ["derive"] }
 
 [profile.release]
 lto = "fat"
+codegen-units = 1


### PR DESCRIPTION
This removes 156KB from the binary size.