### PR TITLE
✨ Add flag to output selection to stdout

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,10 @@ struct Args {
     /// If not specified, the color scheme is autodetected.
     #[arg(short, long)]
     color_scheme: Option<ColorScheme>,
+
+    /// Output the selected emoji to standard out.
+    #[arg(short, long)]
+    stdout: bool,
 }
 
 #[derive(ValueEnum, Debug, Clone, Copy)]
@@ -108,6 +112,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         if let Some(content) = commit_file_content {
             file.write_all(content.as_bytes())?;
         }
+    } else if args.stdout {
+        println!("{}", selected);
     } else {
         println!("Copied {selected} to the clipboard");
         copy_to_clipboard(selected)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ struct Args {
     #[arg(short, long)]
     color_scheme: Option<ColorScheme>,
 
-    /// Output the selected emoji to standard out.
+    /// Output the selected emoji to standard out. Note that this switches the UI to render via stderr.
     #[arg(short, long)]
     stdout: bool,
 }
@@ -99,7 +99,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     };
 
     let color_scheme = get_color_scheme(&args);
-    let selected = match select_emoji(color_scheme.into())? {
+    let selected = match select_emoji(color_scheme.into(), args.stdout)? {
         Some(s) => s,
         None => return Ok(()),
     };
@@ -122,10 +122,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn select_emoji(colors: Colors) -> Result<Option<String>, Box<dyn Error>> {
+fn select_emoji(colors: Colors, use_stderr: bool) -> Result<Option<String>, Box<dyn Error>> {
     let emojis = &emoji::EMOJIS;
 
-    let mut terminal = Terminal::setup()?;
+    let mut terminal = Terminal::setup(use_stderr)?;
     let mut search_entry = SearchEntry::new(&colors);
     let mut selection_view = SelectionView::new(emojis, &colors);
 

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -24,7 +24,7 @@ impl Terminal {
         let backend = CrosstermBackend::new(output);
 
         ratatui::Terminal::new(backend)
-            .map(|x| Self(x))
+            .map(Self)
             .map_err(Into::into)
     }
 

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -5,22 +5,26 @@ use crossterm::{
 use ratatui::backend::CrosstermBackend;
 use std::{
     error::Error,
-    io::{self, Stderr},
+    io::{self, Write},
     ops::{Deref, DerefMut},
 };
 
-pub struct Terminal(ratatui::Terminal<CrosstermBackend<Stderr>>);
+pub struct Terminal(ratatui::Terminal<CrosstermBackend<Box<dyn Write>>>);
 
 impl Terminal {
-    pub fn setup() -> Result<Self, Box<dyn Error>> {
+    pub fn setup(use_stderr: bool) -> Result<Self, Box<dyn Error>> {
         // setup terminal
         enable_raw_mode()?;
-        let mut stderr = io::stderr();
-        execute!(stderr, EnterAlternateScreen)?;
-        let backend = CrosstermBackend::new(stderr);
+        let mut output: Box<dyn Write> = if use_stderr {
+            Box::new(io::stderr())
+        } else {
+            Box::new(io::stdout())
+        };
+        execute!(output, EnterAlternateScreen)?;
+        let backend = CrosstermBackend::new(output);
 
         ratatui::Terminal::new(backend)
-            .map(Self)
+            .map(|x| Self(x))
             .map_err(Into::into)
     }
 
@@ -42,7 +46,7 @@ impl Drop for Terminal {
 }
 
 impl Deref for Terminal {
-    type Target = ratatui::Terminal<CrosstermBackend<Stderr>>;
+    type Target = ratatui::Terminal<CrosstermBackend<Box<dyn Write>>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -5,19 +5,19 @@ use crossterm::{
 use ratatui::backend::CrosstermBackend;
 use std::{
     error::Error,
-    io::{self, Stdout},
+    io::{self, Stderr},
     ops::{Deref, DerefMut},
 };
 
-pub struct Terminal(ratatui::Terminal<CrosstermBackend<Stdout>>);
+pub struct Terminal(ratatui::Terminal<CrosstermBackend<Stderr>>);
 
 impl Terminal {
     pub fn setup() -> Result<Self, Box<dyn Error>> {
         // setup terminal
         enable_raw_mode()?;
-        let mut stdout = io::stdout();
-        execute!(stdout, EnterAlternateScreen)?;
-        let backend = CrosstermBackend::new(stdout);
+        let mut stderr = io::stderr();
+        execute!(stderr, EnterAlternateScreen)?;
+        let backend = CrosstermBackend::new(stderr);
 
         ratatui::Terminal::new(backend)
             .map(Self)
@@ -42,7 +42,7 @@ impl Drop for Terminal {
 }
 
 impl Deref for Terminal {
-    type Target = ratatui::Terminal<CrosstermBackend<Stdout>>;
+    type Target = ratatui::Terminal<CrosstermBackend<Stderr>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0


### PR DESCRIPTION
Closes #221

Switched the UI to output to stderr which then allows for usage in pipes etc. Theoretically there are performance implications for this per [the Ratatui docs](https://ratatui.rs/faq/#should-i-use-stdout-or-stderr) though in practice I didn't notice any degradation.

Another option involving (slightly) more complexity would be to only output the UI to stderr when the stdout option is selected, but given that there is no noticeable downside to outputting to stderr I felt that it was simpler just to make this change universally, let me know what you think!
