### PR TITLE
🔧 Support skipping the changelog via a commit trailer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,3 +53,9 @@ array, eliminating runtime JSON parsing and network dependencies.
 2. **Git hook**: `gimoji --hook <commit-file>` - prepends emoji to commit message
 3. **Initialize**: `gimoji --init` - installs git prepare-commit-msg hook
 4. **Stdout**: `gimoji --stdout` - outputs selection to stdout instead of clipboard
+
+## Commit Conventions
+
+- **Changelog-skip trailer**: end a commit message with a `Changelog: skip` git trailer to
+  keep it out of the user-facing changelog (use for AI-workflow artifacts such as design docs
+  and implementation plans).

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -79,11 +79,26 @@ commit_preprocessors = [
         if [ -n "$ref" ]; then printf "%s||%s\\n" "$title" "$ref"
         else printf "%s\\n" "$title"; fi
     '""" },
+    # Replace the message of commits carrying a "Changelog: skip" git trailer with a sentinel
+    # that the first commit parser below drops (e.g. AI-workflow design docs and plans).
+    { pattern = ".*", replace_command = '''sh -c '
+        title=$(cat)
+        if git log -1 --format="%(trailers:key=Changelog,valueonly)" $COMMIT_SHA 2>/dev/null \
+            | grep -qix skip
+        then
+            echo changelog-skip
+        else
+            printf "%s\n" "$title"
+        fi
+    '
+    ''' },
 ]
 
 # Categorize commits based on gimoji emojis.
 # See: https://zeenix.github.io/gimoji/
 commit_parsers = [
+    # Skip commits carrying a "Changelog: skip" trailer (see the preprocessor above).
+    { message = "^changelog-skip$", skip = true },
     # Skip merge commits, release commits, and empty commits (just emojis).
     { message = "^[Mm]erge", skip = true },
     { message = "^🔖", skip = true },


### PR DESCRIPTION
## What / Why

AI-workflow artifact commits (design docs, implementation plans) currently show up in the
user-facing `CHANGELOG.md`, which is noise for consumers of the changelog. `git-cliff`'s commit
parsers only see the message title, not trailers, so this adds a preprocessor that rewrites the
message of any commit carrying a `Changelog: skip` git trailer into a sentinel (`changelog-skip`),
and a new first commit parser that drops commits matching that sentinel.

Usage: end a commit message with a `Changelog: skip` trailer to keep it out of the changelog. The
convention is now documented in `AGENTS.md` under "Commit Conventions" (this PR's own docs commit
dogfoods the mechanism — it carries the trailer itself and is filtered out below).

## Verification

Ran the release-plz.toml change through a scratch commit matrix on top of this branch (reverted
before pushing): three commits appending to `README.md` — `📝 Skip me A` (trailer), `📝 Keep me B`
(prose mention of "Changelog: skip" mid-body, not a trailer), `📝 Keep me C` (no body) — then
`release-plz update --allow-dirty` (`--allow-dirty` needed on release-plz 0.3.160 due to an
unrelated local Cargo.toml workaround for a nested-worktree cargo quirk, not committed).

Resulting `CHANGELOG.md` diff:
```
+## 1.4.0 - 2026-08-10
+
+### Changed
+- 🔧 Support skipping the changelog via a commit trailer.
+- 🚚 Rename CLAUDE.md to AGENTS.md.
+
...
+### Documentation
+- 📝 Keep me C.
+- 📝 Keep me B.
+- 📝 Document top-down module ordering convention.
```

`Skip me A` is absent; `Keep me B` and `Keep me C` are present — PASS. This branch's own
`📝 Document the changelog-skip trailer convention` docs commit (which carries the trailer) is
likewise absent from the diff, confirming dogfooding works.

Generated by Claude Fable 5 (claude-fable-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vw5uRE2AL6ddxgwqoPTxVr