### PR TITLE
🚑️ Restore emojis.json at the repo root

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,13 @@ Raw cargo also works:
 
 ### Repository Layout
 
+The `emojis.json` at the repo root is a public contract: published
+`commitlint-plugin-gimoji` versions fetch it from main's raw GitHub URL, so
+it must never move. It is a byte-identical copy of
+`crates/gimoji-core/emojis.json` (the crate-local copy `cargo publish`
+needs); `gimoji-core`'s build script fails the build if the two drift, and
+the emoji-update tool rewrites both.
+
 Two cargo roots, both checked into the same repo:
 
 - **Native workspace** (`Cargo.toml` at the repo root) — members:

--- a/crates/gimoji-core/build.rs
+++ b/crates/gimoji-core/build.rs
@@ -27,8 +27,22 @@ pub struct Emojis<'e> {
 
 fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=emojis.json");
+    println!("cargo:rerun-if-changed={ROOT_EMOJI_FILE}");
     let path = PathBuf::from(EMOJI_FILE);
     let emojis_json = read_to_string(path)?;
+
+    // The repo root carries a second copy of emojis.json: its raw GitHub URL
+    // is a public contract — published commitlint-plugin-gimoji versions
+    // fetch it from main. The root copy is absent from the packaged crate,
+    // so this check only runs on repo checkouts.
+    let root_path = PathBuf::from(ROOT_EMOJI_FILE);
+    if root_path.exists() && read_to_string(root_path)? != emojis_json {
+        return Err(format!(
+            "{ROOT_EMOJI_FILE} differs from {EMOJI_FILE}; the root copy is fetched by \
+             commitlint-plugin-gimoji and must stay identical. Copy one over the other."
+        )
+        .into());
+    }
     let emojis: Emojis = serde_json::from_str(&emojis_json)?;
     let baked = (&emojis.gitmojis[..]).bake(&Default::default()).to_string();
 
@@ -43,3 +57,4 @@ fn main() -> Result<(), Box<dyn Error>> {
 }
 
 const EMOJI_FILE: &str = "emojis.json";
+const ROOT_EMOJI_FILE: &str = "../../emojis.json";

--- a/emojis.json
+++ b/emojis.json
@@ -1,0 +1,637 @@
+{
+  "$schema": "https://gitmoji.dev/api/gitmojis/schema",
+  "gitmojis": [
+    {
+      "emoji": "🎨",
+      "entity": "&#x1f3a8;",
+      "code": ":art:",
+      "description": "Improve structure / format of the code.",
+      "name": "art",
+      "semver": null
+    },
+    {
+      "emoji": "⚡️",
+      "entity": "&#x26a1;",
+      "code": ":zap:",
+      "description": "Improve performance.",
+      "name": "zap",
+      "semver": "patch"
+    },
+    {
+      "emoji": "🔥",
+      "entity": "&#x1f525;",
+      "code": ":fire:",
+      "description": "Remove code or files.",
+      "name": "fire",
+      "semver": null
+    },
+    {
+      "emoji": "🐛",
+      "entity": "&#x1f41b;",
+      "code": ":bug:",
+      "description": "Fix a bug.",
+      "name": "bug",
+      "semver": "patch"
+    },
+    {
+      "emoji": "🚑️",
+      "entity": "&#128657;",
+      "code": ":ambulance:",
+      "description": "Critical hotfix.",
+      "name": "ambulance",
+      "semver": "patch"
+    },
+    {
+      "emoji": "✨",
+      "entity": "&#x2728;",
+      "code": ":sparkles:",
+      "description": "Introduce new features.",
+      "name": "sparkles",
+      "semver": "minor"
+    },
+    {
+      "emoji": "📝",
+      "entity": "&#x1f4dd;",
+      "code": ":memo:",
+      "description": "Add or update documentation.",
+      "name": "memo",
+      "semver": null
+    },
+    {
+      "emoji": "🚀",
+      "entity": "&#x1f680;",
+      "code": ":rocket:",
+      "description": "Deploy stuff.",
+      "name": "rocket",
+      "semver": null
+    },
+    {
+      "emoji": "💄",
+      "entity": "&#ff99cc;",
+      "code": ":lipstick:",
+      "description": "Add or update the UI and style files.",
+      "name": "lipstick",
+      "semver": "patch"
+    },
+    {
+      "emoji": "🎉",
+      "entity": "&#127881;",
+      "code": ":tada:",
+      "description": "Begin a project.",
+      "name": "tada",
+      "semver": null
+    },
+    {
+      "emoji": "✅",
+      "entity": "&#x2705;",
+      "code": ":white_check_mark:",
+      "description": "Add, update, or pass tests.",
+      "name": "white-check-mark",
+      "semver": null
+    },
+    {
+      "emoji": "🔒️",
+      "entity": "&#x1f512;",
+      "code": ":lock:",
+      "description": "Fix security or privacy issues.",
+      "name": "lock",
+      "semver": "patch"
+    },
+    {
+      "emoji": "🔐",
+      "entity": "&#x1f510;",
+      "code": ":closed_lock_with_key:",
+      "description": "Add or update secrets.",
+      "name": "closed-lock-with-key",
+      "semver": null
+    },
+    {
+      "emoji": "🔖",
+      "entity": "&#x1f516;",
+      "code": ":bookmark:",
+      "description": "Release / Version tags.",
+      "name": "bookmark",
+      "semver": null
+    },
+    {
+      "emoji": "🚨",
+      "entity": "&#x1f6a8;",
+      "code": ":rotating_light:",
+      "description": "Fix compiler / linter warnings.",
+      "name": "rotating-light",
+      "semver": null
+    },
+    {
+      "emoji": "🚧",
+      "entity": "&#x1f6a7;",
+      "code": ":construction:",
+      "description": "Work in progress.",
+      "name": "construction",
+      "semver": null
+    },
+    {
+      "emoji": "💚",
+      "entity": "&#x1f49a;",
+      "code": ":green_heart:",
+      "description": "Fix CI Build.",
+      "name": "green-heart",
+      "semver": null
+    },
+    {
+      "emoji": "⬇️",
+      "entity": "⬇️",
+      "code": ":arrow_down:",
+      "description": "Downgrade dependencies.",
+      "name": "arrow-down",
+      "semver": "patch"
+    },
+    {
+      "emoji": "⬆️",
+      "entity": "⬆️",
+      "code": ":arrow_up:",
+      "description": "Upgrade dependencies.",
+      "name": "arrow-up",
+      "semver": "patch"
+    },
+    {
+      "emoji": "📌",
+      "entity": "&#x1F4CC;",
+      "code": ":pushpin:",
+      "description": "Pin dependencies to specific versions.",
+      "name": "pushpin",
+      "semver": "patch"
+    },
+    {
+      "emoji": "👷",
+      "entity": "&#x1f477;",
+      "code": ":construction_worker:",
+      "description": "Add or update CI build system.",
+      "name": "construction-worker",
+      "semver": null
+    },
+    {
+      "emoji": "📈",
+      "entity": "&#x1F4C8;",
+      "code": ":chart_with_upwards_trend:",
+      "description": "Add or update analytics or track code.",
+      "name": "chart-with-upwards-trend",
+      "semver": "patch"
+    },
+    {
+      "emoji": "♻️",
+      "entity": "&#x267b;",
+      "code": ":recycle:",
+      "description": "Refactor code.",
+      "name": "recycle",
+      "semver": null
+    },
+    {
+      "emoji": "➕",
+      "entity": "&#10133;",
+      "code": ":heavy_plus_sign:",
+      "description": "Add a dependency.",
+      "name": "heavy-plus-sign",
+      "semver": "patch"
+    },
+    {
+      "emoji": "➖",
+      "entity": "&#10134;",
+      "code": ":heavy_minus_sign:",
+      "description": "Remove a dependency.",
+      "name": "heavy-minus-sign",
+      "semver": "patch"
+    },
+    {
+      "emoji": "🔧",
+      "entity": "&#x1f527;",
+      "code": ":wrench:",
+      "description": "Add or update configuration files.",
+      "name": "wrench",
+      "semver": "patch"
+    },
+    {
+      "emoji": "🔨",
+      "entity": "&#128296;",
+      "code": ":hammer:",
+      "description": "Add or update development scripts.",
+      "name": "hammer",
+      "semver": null
+    },
+    {
+      "emoji": "🌐",
+      "entity": "&#127760;",
+      "code": ":globe_with_meridians:",
+      "description": "Internationalization and localization.",
+      "name": "globe-with-meridians",
+      "semver": "patch"
+    },
+    {
+      "emoji": "✏️",
+      "entity": "&#59161;",
+      "code": ":pencil2:",
+      "description": "Fix typos.",
+      "name": "pencil2",
+      "semver": "patch"
+    },
+    {
+      "emoji": "💩",
+      "entity": "&#58613;",
+      "code": ":poop:",
+      "description": "Write bad code that needs to be improved.",
+      "name": "poop",
+      "semver": null
+    },
+    {
+      "emoji": "⏪️",
+      "entity": "&#9194;",
+      "code": ":rewind:",
+      "description": "Revert changes.",
+      "name": "rewind",
+      "semver": "patch"
+    },
+    {
+      "emoji": "🔀",
+      "entity": "&#128256;",
+      "code": ":twisted_rightwards_arrows:",
+      "description": "Merge branches.",
+      "name": "twisted-rightwards-arrows",
+      "semver": null
+    },
+    {
+      "emoji": "📦️",
+      "entity": "&#1F4E6;",
+      "code": ":package:",
+      "description": "Add or update compiled files or packages.",
+      "name": "package",
+      "semver": "patch"
+    },
+    {
+      "emoji": "👽️",
+      "entity": "&#1F47D;",
+      "code": ":alien:",
+      "description": "Update code due to external API changes.",
+      "name": "alien",
+      "semver": "patch"
+    },
+    {
+      "emoji": "🚚",
+      "entity": "&#1F69A;",
+      "code": ":truck:",
+      "description": "Move or rename resources (e.g.: files, paths, routes).",
+      "name": "truck",
+      "semver": null
+    },
+    {
+      "emoji": "📄",
+      "entity": "&#1F4C4;",
+      "code": ":page_facing_up:",
+      "description": "Add or update license.",
+      "name": "page-facing-up",
+      "semver": null
+    },
+    {
+      "emoji": "💥",
+      "entity": "&#x1f4a5;",
+      "code": ":boom:",
+      "description": "Introduce breaking changes.",
+      "name": "boom",
+      "semver": "major"
+    },
+    {
+      "emoji": "🍱",
+      "entity": "&#1F371",
+      "code": ":bento:",
+      "description": "Add or update assets.",
+      "name": "bento",
+      "semver": "patch"
+    },
+    {
+      "emoji": "♿️",
+      "entity": "&#9855;",
+      "code": ":wheelchair:",
+      "description": "Improve accessibility.",
+      "name": "wheelchair",
+      "semver": "patch"
+    },
+    {
+      "emoji": "💡",
+      "entity": "&#128161;",
+      "code": ":bulb:",
+      "description": "Add or update comments in source code.",
+      "name": "bulb",
+      "semver": null
+    },
+    {
+      "emoji": "🍻",
+      "entity": "&#x1f37b;",
+      "code": ":beers:",
+      "description": "Write code drunkenly.",
+      "name": "beers",
+      "semver": null
+    },
+    {
+      "emoji": "💬",
+      "entity": "&#128172;",
+      "code": ":speech_balloon:",
+      "description": "Add or update text and literals.",
+      "name": "speech-balloon",
+      "semver": "patch"
+    },
+    {
+      "emoji": "🗃️",
+      "entity": "&#128451;",
+      "code": ":card_file_box:",
+      "description": "Perform database related changes.",
+      "name": "card-file-box",
+      "semver": "patch"
+    },
+    {
+      "emoji": "🔊",
+      "entity": "&#128266;",
+      "code": ":loud_sound:",
+      "description": "Add or update logs.",
+      "name": "loud-sound",
+      "semver": null
+    },
+    {
+      "emoji": "🔇",
+      "entity": "&#128263;",
+      "code": ":mute:",
+      "description": "Remove logs.",
+      "name": "mute",
+      "semver": null
+    },
+    {
+      "emoji": "👥",
+      "entity": "&#128101;",
+      "code": ":busts_in_silhouette:",
+      "description": "Add or update contributor(s).",
+      "name": "busts-in-silhouette",
+      "semver": null
+    },
+    {
+      "emoji": "🚸",
+      "entity": "&#128696;",
+      "code": ":children_crossing:",
+      "description": "Improve user experience / usability.",
+      "name": "children-crossing",
+      "semver": "patch"
+    },
+    {
+      "emoji": "🏗️",
+      "entity": "&#1f3d7;",
+      "code": ":building_construction:",
+      "description": "Make architectural changes.",
+      "name": "building-construction",
+      "semver": null
+    },
+    {
+      "emoji": "📱",
+      "entity": "&#128241;",
+      "code": ":iphone:",
+      "description": "Work on responsive design.",
+      "name": "iphone",
+      "semver": "patch"
+    },
+    {
+      "emoji": "🤡",
+      "entity": "&#129313;",
+      "code": ":clown_face:",
+      "description": "Mock things.",
+      "name": "clown-face",
+      "semver": null
+    },
+    {
+      "emoji": "🥚",
+      "entity": "&#129370;",
+      "code": ":egg:",
+      "description": "Add or update an easter egg.",
+      "name": "egg",
+      "semver": "patch"
+    },
+    {
+      "emoji": "🙈",
+      "entity": "&#8bdfe7;",
+      "code": ":see_no_evil:",
+      "description": "Add or update a .gitignore file.",
+      "name": "see-no-evil",
+      "semver": null
+    },
+    {
+      "emoji": "📸",
+      "entity": "&#128248;",
+      "code": ":camera_flash:",
+      "description": "Add or update snapshots.",
+      "name": "camera-flash",
+      "semver": null
+    },
+    {
+      "emoji": "⚗️",
+      "entity": "&#x2697;",
+      "code": ":alembic:",
+      "description": "Perform experiments.",
+      "name": "alembic",
+      "semver": "patch"
+    },
+    {
+      "emoji": "🔍️",
+      "entity": "&#128269;",
+      "code": ":mag:",
+      "description": "Improve SEO.",
+      "name": "mag",
+      "semver": "patch"
+    },
+    {
+      "emoji": "🏷️",
+      "entity": "&#127991;",
+      "code": ":label:",
+      "description": "Add or update types.",
+      "name": "label",
+      "semver": "patch"
+    },
+    {
+      "emoji": "🌱",
+      "entity": "&#127793;",
+      "code": ":seedling:",
+      "description": "Add or update seed files.",
+      "name": "seedling",
+      "semver": null
+    },
+    {
+      "emoji": "🚩",
+      "entity": "&#x1F6A9;",
+      "code": ":triangular_flag_on_post:",
+      "description": "Add, update, or remove feature flags.",
+      "name": "triangular-flag-on-post",
+      "semver": "patch"
+    },
+    {
+      "emoji": "🥅",
+      "entity": "&#x1F945;",
+      "code": ":goal_net:",
+      "description": "Catch errors.",
+      "name": "goal-net",
+      "semver": "patch"
+    },
+    {
+      "emoji": "💫",
+      "entity": "&#x1f4ab;",
+      "code": ":dizzy:",
+      "description": "Add or update animations and transitions.",
+      "name": "dizzy",
+      "semver": "patch"
+    },
+    {
+      "emoji": "🗑️",
+      "entity": "&#x1F5D1;",
+      "code": ":wastebasket:",
+      "description": "Deprecate code that needs to be cleaned up.",
+      "name": "wastebasket",
+      "semver": "patch"
+    },
+    {
+      "emoji": "🛂",
+      "entity": "&#x1F6C2;",
+      "code": ":passport_control:",
+      "description": "Work on code related to authorization, roles and permissions.",
+      "name": "passport-control",
+      "semver": "patch"
+    },
+    {
+      "emoji": "🩹",
+      "entity": "&#x1FA79;",
+      "code": ":adhesive_bandage:",
+      "description": "Simple fix for a non-critical issue.",
+      "name": "adhesive-bandage",
+      "semver": "patch"
+    },
+    {
+      "emoji": "🧐",
+      "entity": "&#x1F9D0;",
+      "code": ":monocle_face:",
+      "description": "Data exploration/inspection.",
+      "name": "monocle-face",
+      "semver": null
+    },
+    {
+      "emoji": "⚰️",
+      "entity": "&#x26B0;",
+      "code": ":coffin:",
+      "description": "Remove dead code.",
+      "name": "coffin",
+      "semver": null
+    },
+    {
+      "emoji": "🧪",
+      "entity": "&#x1F9EA;",
+      "code": ":test_tube:",
+      "description": "Add a failing test.",
+      "name": "test-tube",
+      "semver": null
+    },
+    {
+      "emoji": "👔",
+      "entity": "&#128084;",
+      "code": ":necktie:",
+      "description": "Add or update business logic.",
+      "name": "necktie",
+      "semver": "patch"
+    },
+    {
+      "emoji": "🩺",
+      "entity": "&#x1FA7A;",
+      "code": ":stethoscope:",
+      "description": "Add or update healthcheck.",
+      "name": "stethoscope",
+      "semver": null
+    },
+    {
+      "emoji": "🧱",
+      "entity": "&#x1f9f1;",
+      "code": ":bricks:",
+      "description": "Infrastructure related changes.",
+      "name": "bricks",
+      "semver": null
+    },
+    {
+      "emoji": "🧑‍💻",
+      "entity": "&#129489;&#8205;&#128187;",
+      "code": ":technologist:",
+      "description": "Improve developer experience.",
+      "name": "technologist",
+      "semver": null
+    },
+    {
+      "emoji": "💸",
+      "entity": "&#x1F4B8;",
+      "code": ":money_with_wings:",
+      "description": "Add sponsorships or money related infrastructure.",
+      "name": "money-with-wings",
+      "semver": null
+    },
+    {
+      "emoji": "🧵",
+      "entity": "&#x1F9F5;",
+      "code": ":thread:",
+      "description": "Add or update code related to multithreading or concurrency.",
+      "name": "thread",
+      "semver": null
+    },
+    {
+      "emoji": "🦺",
+      "entity": "&#x1F9BA;",
+      "code": ":safety_vest:",
+      "description": "Add or update code related to validation.",
+      "name": "safety-vest",
+      "semver": null
+    },
+    {
+      "emoji": "✈️",
+      "entity": "&#x2708;",
+      "code": ":airplane:",
+      "description": "Improve offline support.",
+      "name": "airplane",
+      "semver": null
+    },
+    {
+      "emoji": "🦖",
+      "entity": "&#x2708;",
+      "code": ":t-rex:",
+      "description": "Code that adds backwards compatibility.",
+      "name": "t-rex",
+      "semver": null
+    },
+    {
+      "emoji": "🔌",
+      "entity": "&#x1F50C;",
+      "code": ":electric_plug:",
+      "description": "Add or update code related to connectivity.",
+      "name": "electric-plug",
+      "semver": null
+    },
+    {
+      "emoji": "🤖",
+      "entity": "&#x1F916;",
+      "code": ":robot:",
+      "description": "Changes related to automation/bots.",
+      "name": "robot",
+      "semver": null
+    },
+    {
+      "emoji": "💣",
+      "entity": "&#x1F4A3;",
+      "code": ":bomb:",
+      "description": "Fix a crash.",
+      "name": "bomb",
+      "semver": null
+    },
+    {
+      "emoji": "🐰",
+      "entity": "&#x1F430;",
+      "code": ":rabbit:",
+      "description": "Changes related to fuzzing.",
+      "name": "rabbit",
+      "semver": null
+    }
+  ]
+}

--- a/packages/commitlint-config-gimoji/package.json
+++ b/packages/commitlint-config-gimoji/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gimoji/commitlint-config-gimoji",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "index.mjs",
   "type": "module",
   "repository": {
@@ -24,7 +24,7 @@
   },
   "peerDependencies": {
     "@commitlint/lint": ">=7.6.0",
-    "@gimoji/commitlint-plugin-gimoji": "0.1.0"
+    "@gimoji/commitlint-plugin-gimoji": "^0.1.0"
   },
   "files": [
     "index.mjs"

--- a/packages/commitlint-plugin-gimoji/index.mjs
+++ b/packages/commitlint-plugin-gimoji/index.mjs
@@ -1,14 +1,27 @@
 import * as assert from "node:assert";
 
+// The root path is the stable public location; the crate path is a fallback
+// so the plugin keeps working from a checkout where only the crate copy
+// exists (e.g. a PR that moves the file).
+const EMOJIS_URLS = [
+  "https://raw.githubusercontent.com/zeenix/gimoji/refs/heads/main/emojis.json",
+  "https://raw.githubusercontent.com/zeenix/gimoji/refs/heads/main/crates/gimoji-core/emojis.json",
+];
+
 let gimojis;
-try {
-  const res = await fetch(
-    "https://raw.githubusercontent.com/zeenix/gimoji/refs/heads/main/emojis.json",
-  );
-  assert.ok(res.ok);
-  const json = await res.json();
-  gimojis = json.gitmojis.map(({ emoji }) => emoji);
-} catch (cause) {
+let cause;
+for (const url of EMOJIS_URLS) {
+  try {
+    const res = await fetch(url);
+    assert.ok(res.ok);
+    const json = await res.json();
+    gimojis = json.gitmojis.map(({ emoji }) => emoji);
+    break;
+  } catch (e) {
+    cause = e;
+  }
+}
+if (gimojis === undefined) {
   throw new Error("unable to fetch gimoji emojis.json", { cause });
 }
 

--- a/packages/commitlint-plugin-gimoji/package.json
+++ b/packages/commitlint-plugin-gimoji/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gimoji/commitlint-plugin-gimoji",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "index.mjs",
   "type": "module",
   "repository": {

--- a/scripts/src/main.rs
+++ b/scripts/src/main.rs
@@ -15,6 +15,9 @@ use serde::{Deserialize, Serialize};
 
 const UPSTREAM_URL: &str = "https://raw.githubusercontent.com/carloscuesta/gitmoji/refs/heads/master/packages/gitmojis/src/gitmojis.json";
 const EMOJIS_FILE: &str = "../crates/gimoji-core/emojis.json";
+// Kept in lockstep with EMOJIS_FILE: the root copy's raw GitHub URL is a
+// public contract fetched by published commitlint-plugin-gimoji versions.
+const ROOT_EMOJIS_FILE: &str = "../emojis.json";
 
 #[derive(Parser)]
 #[command(name = "update-emojis")]
@@ -168,6 +171,7 @@ fn update_database(
 
     if has_changes {
         fs::write(EMOJIS_FILE, &new_content)?;
+        fs::write(ROOT_EMOJIS_FILE, &new_content)?;
         println!("✅ Database updated successfully!");
     } else {
         println!("ℹ️  No changes detected - database is already up to date!");


### PR DESCRIPTION
The workspace restructure (#340) moved `emojis.json` into `crates/gimoji-core/`, breaking a URL
that is effectively public API: published `commitlint-plugin-gimoji` versions fetch
`raw.githubusercontent.com/zeenix/gimoji/refs/heads/main/emojis.json`, so commitlint began
failing in this repo and in every project using the plugin as soon as the merge landed.

## Fix

* Restore `emojis.json` at the repo root (byte-identical copy of the crate's file).
* `gimoji-core`'s build script now fails any repo build where the two copies drift, with a
  message saying which file to copy where. The check self-disables in the published crate,
  where the root copy doesn't exist (`cargo publish --dry-run` verified).
* The monthly emoji-update tool rewrites both copies.
* The plugin gains a fallback fetch of the crate path (and a version bump to 0.1.1) so it
  survives states where only one copy is reachable — including this very PR's commitlint job,
  which runs before the root copy is back on main.
* `AGENTS.md` documents the contract so no future restructure moves the file again.

Verified: the drift guard fails the build with a clear message when the copies differ and
passes when identical; the patched plugin was exercised against live URLs while the root copy
is still 404 (fallback path taken, rule evaluates correctly).

Merging this unbreaks all consumers immediately — old plugin versions fetch from `main`, so no
npm release is required for that. Publishing 0.1.1 (manual `npm-publish` workflow) is optional
hardening.

Generated by Claude Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qmcMQaQSrGKYj3zeonwRx