### PR TITLE
🔧 Version and release the two crates independently

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ resolver = "2"
 exclude = ["scripts", "crates/gimoji-web"]
 
 [workspace.package]
-version = "1.4.0"
 edition = "2021"
 license = "MIT"
 authors = ["Zeeshan Ali Khan <zeeshanak@gnome.org>"]

--- a/crates/gimoji-core/CHANGELOG.md
+++ b/crates/gimoji-core/CHANGELOG.md
@@ -10,36 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - ✨ Add a WebAssembly frontend painting through a Canvas-2D backend.
 - ✨ Drive the picker via a shared `App` state machine in gimoji-core.
-- ✨ Only give up on adding emoji prefix if one is already present. #32
-- ✨ Copy the selected emoji to the clipboard. #7
 
 ### Changed
 - 🏗️ Restructure into a Cargo workspace with a shared core library.
-- 💄 Replace screenshot with a screencast demo.
 
 ### Documentation
 - 📝 Round out gimoji-core's crates.io metadata.
-- 📝 correct footnote notation for new link.
-- 📝 document how to use `gimoji` with `lefthook`.
-- 📝 Be specific about git commit message hook into docs.
-- 📝 Correct minimum Fedora version.
-- 📝 Drop `Core` from Fedora's name.
-- 📝 Add Fedora installation instructions. #25
-- 📝 Update README as par the new emoji handling mechanism/philosophy.
-- 📝 Update README with correct --init flag.
-- 📝 Specify path to the screenshot.
-- 📝 Fix build status badge in README.
-- 📝 Add README.
 
 ### Fixed
 - 🚑️ Restore emojis.json at the repo root.
 - 🐛 Stop arrow keys panicking when the filter matches nothing.
 
-### Other
-- Fix minor typos.
-- ✏️  A minor formatting fix.
-- Fix typo in link name.
-
 ### Removed
 - 🔥 Replace the JS-templated bundle script with serve-web.sh.
-- 🔥 Remove `gitmoji` badge.

--- a/crates/gimoji-core/Cargo.toml
+++ b/crates/gimoji-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gimoji-core"
 description = "Core picker UI and emoji database shared by gimoji's native and web frontends"
-version.workspace = true
+version = "1.4.0"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/gimoji/CHANGELOG.md
+++ b/crates/gimoji/CHANGELOG.md
@@ -8,7 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 1.4.0 - 2026-08-12
 
 ### Added
+- ✨ Add a WebAssembly frontend painting through a Canvas-2D backend.
 - ✨ Drive the picker via a shared `App` state machine in gimoji-core.
 
 ### Changed
 - 🏗️ Restructure into a Cargo workspace with a shared core library.
+
+### Documentation
+- 📝 Round out gimoji-core's crates.io metadata.
+
+### Fixed
+- 🚑️ Restore emojis.json at the repo root.
+- 🩹 Fall back to the crate copy when fetching emojis.json.
+- 🐛 Stop arrow keys panicking when the filter matches nothing.
+
+### Removed
+- 🔥 Replace the JS-templated bundle script with serve-web.sh.

--- a/crates/gimoji/Cargo.toml
+++ b/crates/gimoji/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gimoji"
 description = "Easily add emojis to your git commit messages 🎉"
-version.workspace = true
+version = "1.4.0"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -12,14 +12,30 @@ git_tag_enable = true
 publish = true
 # We're not a library.
 semver_check = false
- 
+
 # Bump minor version for non-bugfix commits.
 custom_minor_increment_regex = """\
 ^(🎨|⚡️|🔥|✨|💄|🎉|🔒️|⬇️|⬆️|📌|➕|➖|🔧|👽️|💥|♿️|💬|🔊|🔇|🚸|🏗️|🗑️)\
 """
 
-# PR configuration.
-pr_name = "🔖 Release {{ version }}"
+# PR configuration. `version` is only available when the released packages
+# all share one version, so fall back to a bare title once they diverge.
+pr_name = "🔖 Release{% if version %} {{ version }}{% endif %}"
+
+# The crates are versioned and released independently. The user-facing
+# `gimoji` binary keeps the historical bare "{{ version }}" tags and owns the
+# GitHub releases; `gimoji-core` gets package-prefixed tags and no GitHub
+# release of its own.
+[[package]]
+name = "gimoji"
+# Fold gimoji-core's commits into the binary's changelog so the release notes
+# cover the whole picker.
+changelog_include = ["gimoji-core"]
+
+[[package]]
+name = "gimoji-core"
+git_tag_name = "gimoji-core-{{ version }}"
+git_release_enable = false
 
 # Changelog configuration for gimoji-based commits.
 # See: https://zeenix.github.io/gimoji/


### PR DESCRIPTION
## Summary

`release-plz release` for 1.4.0 died halfway: both workspace crates shared the workspace version
and the workspace-wide `git_tag_name = "{{ version }}"`, so gimoji-core's release step claimed
tag `1.4.0` and gimoji's step then failed with `Reference already exists` (GitHub 422).

Since the two crates can contain independent changes, split the versioning instead of sharing one
workspace version:

- Each crate now carries its own `version` (both currently 1.4.0, matching crates.io).
- `gimoji` keeps the historical bare `{{ version }}` tags and owns the GitHub releases.
- `gimoji-core` gets `gimoji-core-{{ version }}` tags and no GitHub release of its own, keeping
  the Releases page user-facing.
- `changelog_include = ["gimoji-core"]` on `gimoji` so the binary's release notes also cover
  core commits — this cycle, path attribution put the wasm frontend and the arrow-key panic fix in
  core's changelog only.
- The release-PR title falls back to a version-less "🔖 Release" once the crate versions diverge,
  since release-plz only populates `version` when all released packages share one.
- Correct both 1.4.0 changelog sections: trim gimoji-core's bootstrap changelog, which swept in
  years of pre-workspace history as if released now, and complete gimoji's, which path attribution
  had left blind to the core-side changes.

The 1.4.0 tags and GH release were repaired manually to match this scheme: `1.4.0` now points at
the gimoji-attributed tag object release-plz had left dangling, `gimoji-core-1.4.0` was created
from the original gimoji-core tag object, and the release notes were replaced with this cycle's
actual changes.

## Verification

`cargo metadata` resolves for both the workspace and gimoji-web, and
`release-plz release --dry-run` with this config parses cleanly and reports both packages as
fully released under their respective tag schemes:

```
INFO gimoji-core 1.4.0: Already published - Tag gimoji-core-1.4.0 already exists
INFO gimoji 1.4.0: Already published - Tag 1.4.0 already exists
```

---
Generated by Claude Fable 5.
https://claude.ai/code/session_0182e8vG8PgfjQmjfRJ3Sast