### PR TITLE
🔧 Give gimoji-core its own GitHub releases

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,9 +2,10 @@
 # https://release-plz.dev/docs/config
 
 [workspace]
-# Use the existing tag naming convention without 'v' prefix.
+# Use the existing tag naming convention without 'v' prefix. Release names
+# are freeform and human-readable, unlike the tags.
 git_tag_name = "{{ version }}"
-git_release_name = "{{ version }}"
+git_release_name = "{{ package }} {{ version }}"
 
 # Enable all release features.
 git_release_enable = true
@@ -23,9 +24,8 @@ custom_minor_increment_regex = """\
 pr_name = "🔖 Release{% if version %} {{ version }}{% endif %}"
 
 # The crates are versioned and released independently. The user-facing
-# `gimoji` binary keeps the historical bare "{{ version }}" tags and owns the
-# GitHub releases; `gimoji-core` gets package-prefixed tags and no GitHub
-# release of its own.
+# `gimoji` binary keeps the historical bare "{{ version }}" tags and GitHub
+# releases; `gimoji-core` gets package-prefixed ones.
 [[package]]
 name = "gimoji"
 # Fold gimoji-core's commits into the binary's changelog so the release notes
@@ -35,7 +35,6 @@ changelog_include = ["gimoji-core"]
 [[package]]
 name = "gimoji-core"
 git_tag_name = "gimoji-core-{{ version }}"
-git_release_enable = false
 
 # Changelog configuration for gimoji-based commits.
 # See: https://zeenix.github.io/gimoji/


### PR DESCRIPTION
## Summary

Follow-up to #344: gimoji-core now gets its own GitHub release per version, so each independently
released crate has an entry on the Releases page. Release titles are freeform, so both crates use
a human-readable `{{ package }} {{ version }}` name (e.g. "gimoji 1.4.0", "gimoji-core
1.4.0") via the workspace-level `git_release_name`, while tags keep their machine-style
schemes. The 1.4.0 entries were retitled and the `gimoji-core 1.4.0` release backfilled
manually; this config makes release-plz do it for future releases.

## Verification

`release-plz release --dry-run` parses the config cleanly and reports both packages as fully
released:

```
INFO gimoji-core 1.4.0: Already published - Tag gimoji-core-1.4.0 already exists
INFO gimoji 1.4.0: Already published - Tag 1.4.0 already exists
```

---
Generated by Claude Fable 5.
https://claude.ai/code/session_0182e8vG8PgfjQmjfRJ3Sast